### PR TITLE
Allow missing IdP hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented here.
 
+## Version [1.1.1]
+
+- Allowed `kc_idp_hint` to be missing for the whitelist authenticator
+
 ## Version [1.1.0]
 
 - Authenticator extension which rejects authentication if client does not match a whitelist from selected IdP

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   </modules>
 
   <properties>
-    <projectVersion>1.1.0</projectVersion>
+    <projectVersion>1.1.1</projectVersion>
     <keycloak.version>16.1.1</keycloak.version>
     <java.version>11</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/start_for_testing.sh
+++ b/start_for_testing.sh
@@ -8,7 +8,7 @@ function cleanup {
 trap cleanup EXIT
 
 # build extension without SNAPSHOT suffix
-mvn clean package -DskipTests
+mvn clean package -DskipTests -DprojectVersion=docker
 if [[ "$?" -ne 0 ]] ; then
   echo 'could not run maven package'; exit $rc
 fi

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -18,10 +18,9 @@ services:
     - /etc/localtime:/etc/localtime:ro
     - "./fwu-realm.json:/opt/keycloak/imports/fwu-realm.json"
     - "./whitelist_realm.json:/opt/keycloak/imports/whitelist_realm.json"
-    - "../remove-user-on-logout/target/remove-user-on-logout-1.0.1.jar:/opt/jboss/keycloak/standalone/deployments/remove-user-on-logout.jar"
-    - "../hmac-mapper/target/hmac-mapper-1.0.1.jar:/opt/jboss/keycloak/standalone/deployments/hmac-mapper.jar"
-    - "./config-script.cli:/opt/jboss/startup-scripts/config-script.cli"
-    - "../whitelist-authenticator/target/whitelist-authenticator-1.0.1.jar:/opt/jboss/keycloak/standalone/deployments/whitelist-authenticator.jar"
+    - "../remove-user-on-logout/target/remove-user-on-logout-docker.jar:/opt/jboss/keycloak/standalone/deployments/remove-user-on-logout.jar"
+    - "../hmac-mapper/target/hmac-mapper-docker.jar:/opt/jboss/keycloak/standalone/deployments/hmac-mapper.jar"
+    - "../whitelist-authenticator/target/whitelist-authenticator-docker.jar:/opt/jboss/keycloak/standalone/deployments/whitelist-authenticator.jar"
     networks:
     - fwunet
 

--- a/whitelist-authenticator/src/main/java/de/intension/authentication/WhitelistAuthenticator.java
+++ b/whitelist-authenticator/src/main/java/de/intension/authentication/WhitelistAuthenticator.java
@@ -1,6 +1,5 @@
 package de.intension.authentication;
 
-import java.util.Formatter;
 import java.util.List;
 import java.util.Map;
 
@@ -38,7 +37,7 @@ public class WhitelistAuthenticator
         String clientId = context.getAuthenticationSession().getClient().getClientId();
         String providerId = context.getUriInfo().getQueryParameters().getFirst(AdapterConstants.KC_IDP_HINT);
         if (!isAllowedIdP(context, clientId, providerId)) {
-            String info = new Formatter().format("IdP with providerId=%s is not configured for clientId=%s", providerId, clientId).toString();
+            String info = String.format("IdP with providerId=%s is not configured for clientId=%s", providerId, clientId);
             logger.info(info);
             Response response = ErrorPage.error(context.getSession(), context.getAuthenticationSession(), Response.Status.FORBIDDEN, info);
             context.failure(AuthenticationFlowError.IDENTITY_PROVIDER_DISABLED, response);
@@ -80,6 +79,9 @@ public class WhitelistAuthenticator
      */
     private boolean isAllowedIdP(AuthenticationFlowContext context, String clientId, String providerId)
     {
+        if (providerId == null || providerId.isEmpty()) {
+            return true;
+        }
         AuthenticatorConfigModel authenticatorConfig = context.getAuthenticatorConfig();
         Map<String, String> config = authenticatorConfig.getConfig();
         String allowedIdPs = config.get(WhitelistAuthenticatorFactory.LIST_OF_ALLOWED_IDP);

--- a/whitelist-authenticator/src/test/java/de/intension/authentication/WhitelistAuthenticatorTest.java
+++ b/whitelist-authenticator/src/test/java/de/intension/authentication/WhitelistAuthenticatorTest.java
@@ -1,0 +1,190 @@
+package de.intension.authentication;
+
+import static de.intension.authentication.WhitelistAuthenticatorFactory.LIST_OF_ALLOWED_IDP;
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.keycloak.constants.AdapterConstants.KC_IDP_HINT;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.authentication.AuthenticationFlowContext;
+import org.keycloak.authentication.AuthenticationFlowError;
+import org.keycloak.forms.login.LoginFormsProvider;
+import org.keycloak.models.AuthenticatorConfigModel;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.mockito.Mockito;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import de.intension.authentication.dto.WhitelistEntry;
+
+class WhitelistAuthenticatorTest
+{
+
+    @Test
+    void should_whitelist()
+        throws JsonProcessingException
+    {
+        var whitelist = new WhitelistEntry();
+        whitelist.setClientId("app");
+        whitelist.setListOfIdPs(List.of("facebook", "google"));
+        var context = mockContext("app", "facebook", List.of(whitelist));
+
+        authenticate(context);
+
+        assertEquals(Boolean.TRUE, context.getSuccess());
+    }
+
+    @Test
+    void should_not_whitelist_if_client_is_not_configured()
+        throws JsonProcessingException
+    {
+        var whitelist = new WhitelistEntry();
+        whitelist.setClientId("not");
+        whitelist.setListOfIdPs(List.of("facebook", "google"));
+        var context = mockContext("app", "facebook", List.of(whitelist));
+
+        authenticate(context);
+
+        assertEquals(Boolean.FALSE, context.getSuccess());
+    }
+
+    @Test
+    void should_not_whitelist_if_idp_is_not_in_list()
+        throws JsonProcessingException
+    {
+        var whitelist = new WhitelistEntry();
+        whitelist.setClientId("app");
+        whitelist.setListOfIdPs(List.of("google"));
+        var context = mockContext("app", "facebook", List.of(whitelist));
+
+        authenticate(context);
+
+        assertEquals(Boolean.FALSE, context.getSuccess());
+    }
+
+    @Test
+    void should_whitelist_if_idp_hint_is_missing()
+        throws JsonProcessingException
+    {
+        var whitelist = new WhitelistEntry();
+        whitelist.setClientId("app");
+        whitelist.setListOfIdPs(List.of("google"));
+        var context = mockContext("app", "", List.of(whitelist));
+
+        authenticate(context);
+
+        assertEquals(Boolean.TRUE, context.getSuccess());
+    }
+
+    @Test
+    void should_whitelist_if_idp_hint_is_missing_and_config_allows_missing_hint()
+        throws JsonProcessingException
+    {
+        var whitelist = new WhitelistEntry();
+        whitelist.setClientId("app");
+        whitelist.setListOfIdPs(List.of("google", ""));
+        var context = mockContext("app", "", List.of(whitelist));
+
+        authenticate(context);
+
+        assertEquals(Boolean.TRUE, context.getSuccess());
+    }
+
+    @Test
+    void should_not_whitelist_if_config_allows_missing_hint_and_idp_hint_is_set()
+        throws JsonProcessingException
+    {
+        var whitelist = new WhitelistEntry();
+        whitelist.setClientId("app");
+        whitelist.setListOfIdPs(List.of("google", ""));
+        var context = mockContext("app", "facebook", List.of(whitelist));
+
+        authenticate(context);
+
+        assertEquals(Boolean.FALSE, context.getSuccess());
+    }
+
+    private TestContext mockContext(String clientId, String kcIdpHint, List<WhitelistEntry> allowedIdps)
+        throws JsonProcessingException
+    {
+        TestContext context = mock(TestContext.class);
+
+        // clientId return value
+        var authSession = mock(AuthenticationSessionModel.class);
+        when(context.getAuthenticationSession()).thenReturn(authSession);
+        var client = mock(ClientModel.class);
+        when(authSession.getClient()).thenReturn(client);
+        when(client.getClientId()).thenReturn(clientId);
+
+        // kc_id_hint
+        var uriInfo = mock(UriInfo.class);
+        when(context.getUriInfo()).thenReturn(uriInfo);
+        var map = new MultivaluedHashMap<>(Map.of(KC_IDP_HINT, kcIdpHint));
+        when(uriInfo.getQueryParameters()).thenReturn(map);
+
+        // whitelist config
+        var authConfig = mock(AuthenticatorConfigModel.class);
+        when(context.getAuthenticatorConfig()).thenReturn(authConfig);
+        var objectMapper = new ObjectMapper();
+        var configMap = Map.of(LIST_OF_ALLOWED_IDP, objectMapper.writeValueAsString(allowedIdps));
+        when(authConfig.getConfig()).thenReturn(configMap);
+
+        // success/failure
+        doCallRealMethod().when(context).success();
+        doCallRealMethod().when(context).failure(Mockito.any(), Mockito.any());
+        when(context.getSuccess()).thenCallRealMethod();
+
+        // error page
+        var keycloakSession = mock(KeycloakSession.class);
+        when(context.getSession()).thenReturn(keycloakSession);
+        var provider = mock(LoginFormsProvider.class);
+        when(keycloakSession.getProvider(LoginFormsProvider.class)).thenReturn(provider);
+        when(provider.setAuthenticationSession(Mockito.any())).thenReturn(provider);
+        when(provider.setError(Mockito.anyString(), Mockito.any())).thenReturn(provider);
+        when(provider.createErrorPage(Mockito.any())).thenReturn(Response.status(FORBIDDEN).build());
+
+        return context;
+    }
+
+    private void authenticate(AuthenticationFlowContext context)
+    {
+        new WhitelistAuthenticator().authenticate(context);
+    }
+
+    private abstract class TestContext
+        implements AuthenticationFlowContext
+    {
+
+        private Boolean success = null;
+
+        @Override
+        public void success()
+        {
+            success = Boolean.TRUE;
+        }
+
+        @Override
+        public void failure(AuthenticationFlowError error, Response response)
+        {
+            success = Boolean.FALSE;
+        }
+
+        public Boolean getSuccess()
+        {
+            return success;
+        }
+    }
+}


### PR DESCRIPTION
This is the case when the OpenID client does not forward the `kc_idp_hint` which is provided by the magic button