### PR TITLE
Update extensions to Keycloak 20.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented here.
 
+## Version [3.0.0]
+
+- Update extensions and docker-compose-file to use keycloack 20.0.1 
+
 ## Version [2.4.0]
 
 - New feature: Prefixed attribute mapper - Prefixes single- and multi-valued claim values

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <projectVersion>2.4.0</projectVersion>
-    <keycloak.version>16.1.1</keycloak.version>
+    <keycloak.version>20.0.1</keycloak.version>
     <java.version>11</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -36,6 +36,24 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>5.8.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.8.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.8.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <version>1.8.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -90,6 +108,12 @@
         <version>2.9.1</version>
       </dependency>
       <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>31.1-jre</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver-netty</artifactId>
         <version>5.14.0</version>
@@ -102,12 +126,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.jboss.resteasy</groupId>
-        <artifactId>resteasy-jackson2-provider</artifactId>
-        <version>3.15.1.Final</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>junit-jupiter</artifactId>
         <version>1.17.3</version>
@@ -116,7 +134,7 @@
       <dependency>
         <groupId>com.github.dasniko</groupId>
         <artifactId>testcontainers-keycloak</artifactId>
-        <version>1.10.0</version>
+        <version>2.4.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   </modules>
 
   <properties>
-    <projectVersion>2.4.0</projectVersion>
+    <projectVersion>3.0.0</projectVersion>
     <keycloak.version>20.0.1</keycloak.version>
     <java.version>11</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/remove-user-on-logout/pom.xml
+++ b/remove-user-on-logout/pom.xml
@@ -42,8 +42,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-jackson2-provider</artifactId>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -2,30 +2,30 @@ version: '3.7'
 services:
   keycloak:
     container_name: keycloak
-    image: quay.io/keycloak/keycloak:16.1.1
+    image: quay.io/keycloak/keycloak:20.0.1
     ports:
     - 18080:8080
     - 8787:8787
     environment:
-      KEYCLOAK_USER: admin
-      KEYCLOAK_PASSWORD: keycloak
-      KEYCLOAK_IMPORT: /opt/keycloak/imports/whitelist_realm.json,/opt/keycloak/imports/fwu-realm.json,/opt/keycloak/imports/idp-realm.json
+      KC_HTTP_RELATIVE_PATH: "/auth"
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: keycloak
       DB_ADDR: postgres
       DB_USER: keycloak
       DB_PASSWORD: password
-    command: ["-b", "0.0.0.0", "--debug", "*:8787"]
+    command: ["start-dev", "--import-realm"]
     volumes:
     - /etc/localtime:/etc/localtime:ro
-    - "./fwu-realm.json:/opt/keycloak/imports/fwu-realm.json"
-    - "./whitelist_realm.json:/opt/keycloak/imports/whitelist_realm.json"
-    - "./idp-realm.json:/opt/keycloak/imports/idp-realm.json"
-    - "../remove-user-on-logout/target/remove-user-on-logout-docker.jar:/opt/jboss/keycloak/standalone/deployments/remove-user-on-logout.jar"
-    - "../hmac-mapper/target/hmac-mapper-docker.jar:/opt/jboss/keycloak/standalone/deployments/hmac-mapper.jar"
-    - "../whitelist-authenticator/target/whitelist-authenticator-docker.jar:/opt/jboss/keycloak/standalone/deployments/whitelist-authenticator.jar"
-    - "../whitelist-authenticator-schools/target/whitelist-authenticator-schools-docker.jar:/opt/jboss/keycloak/standalone/deployments/whitelist-authenticator-schools.jar"
-    - "../multi-value-user-attribute-mapper/target/multi-value-user-attribute-mapper-docker.jar:/opt/jboss/keycloak/standalone/deployments/multi-value-user-attribute-mapper.jar"
-    - "../acronym-mapper/target/acronym-mapper-docker.jar:/opt/jboss/keycloak/standalone/deployments/acronym-mapper.jar"
-    - "../school-mapper/target/school-mapper-docker.jar:/opt/jboss/keycloak/standalone/deployments/school-mapper.jar"
+    - "./fwu-realm.json:/opt/keycloak/data/import/fwu-realm.json"
+    - "./whitelist_realm.json:/opt/keycloak/data/import/whitelist_realm.json"
+    - "./idp-realm.json:/opt/keycloak/data/import/idp-realm.json"
+    - "../remove-user-on-logout/target/remove-user-on-logout-docker.jar:/opt/keycloak/providers/remove-user-on-logout.jar"
+    - "../hmac-mapper/target/hmac-mapper-docker.jar:/opt/keycloak/providers/hmac-mapper.jar"
+    - "../whitelist-authenticator/target/whitelist-authenticator-docker.jar:/opt/keycloak/providers/whitelist-authenticator.jar"
+    - "../whitelist-authenticator-schools/target/whitelist-authenticator-schools-docker.jar:/opt/keycloak/providers/whitelist-authenticator-schools.jar"
+    - "../multi-value-user-attribute-mapper/target/multi-value-user-attribute-mapper-docker.jar:/opt/keycloak/providers/multi-value-user-attribute-mapper.jar"
+    - "../acronym-mapper/target/acronym-mapper-docker.jar:/opt/keycloak/providers/acronym-mapper.jar"
+    - "../school-mapper/target/school-mapper-docker.jar:/opt/keycloak/providers/school-mapper.jar"
     networks:
     - fwunet
     depends_on:

--- a/whitelist-authenticator/src/main/resources/theme-resources/messages/messages_de.properties
+++ b/whitelist-authenticator/src/main/resources/theme-resources/messages/messages_de.properties
@@ -1,1 +1,1 @@
-idpNotConfigured=Diese Anwendung an dieser Anwendung ist mit Deinem Nutzerkonto derzeit nicht m\u00F6glich. Bei Fragen wende dich bitte an den Support deines Portals oder an den VIDIS Support <a href="https://vidis.schule/support">vidis.schule/support</a>
+idpNotConfigured=Die Anmeldung an dieser Anwendung ist mit Deinem Nutzerkonto derzeit nicht m\u00F6glich. Bei Fragen wende dich bitte an den Support deines Portals oder an den VIDIS Support <a href="https://vidis.schule/support">vidis.schule/support</a>


### PR DESCRIPTION

Update extensions and docker-comopse-file to use keycloak version 20.0.1.
Remove explicitly declared test-dependency of resteasy-jackson2-provider to avoid conflicting dependencies.
Improve wording in messages_de.properties. Message match test from postman-collection.