### PR TITLE
Replace deprecated calls to save Outputs in github action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,7 +36,7 @@ jobs:
           response=$(curl -H 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/FWU-DE/fwu-kc-extensions/releases/tags/$TAG)
           message=$(echo $response | jq -r .message)
           if [ "$message" == "Not Found" ]; then
-            echo "::set-output name=version::$TAG"
+            echo "version=$TAG" >> $GITHUB_OUPUT
             modules=$(mvn -Dexec.executable='echo' -Dexec.args='${project.artifactId}' exec:exec -q)
             for module in $modules
             do
@@ -45,7 +45,7 @@ jobs:
               fi
             done
             csv=$(paste -s -d , modules.txt)
-            echo "::set-output name=artifacts::$csv"
+            echo "artifacts=$csv" >> $GITHUB_OUTPUT
           else
             echo "Release $TAG already exists!"
           fi


### PR DESCRIPTION
replace echo with ::save-output syntax with output to new enviroment file $GITHUB_OUTPUT. 
see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/