### PR TITLE
VIAM-115 hmac-mapperextension: adding pseudonyms of other clients

### DIFF
--- a/hmac-mapper/src/main/java/de/intension/protocol/oidc/mappers/HmacPairwisePseudonymListMapper.java
+++ b/hmac-mapper/src/main/java/de/intension/protocol/oidc/mappers/HmacPairwisePseudonymListMapper.java
@@ -1,0 +1,206 @@
+package de.intension.protocol.oidc.mappers;
+
+import java.util.*;
+
+import org.jboss.logging.Logger;
+import org.keycloak.models.*;
+import org.keycloak.protocol.ProtocolMapperConfigException;
+import org.keycloak.protocol.oidc.mappers.*;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.representations.IDToken;
+
+/**
+ * Pairwise identifier mapper using
+ * <a href="https://datatracker.ietf.org/doc/html/rfc2104">HMAC</a>.
+ * This OIDC mapper will add the {@code pseudonyms} field in the token with a list of Pseudonyms
+ * from
+ * the {@link HmacPairwiseSubMapper} of the configured Clients. Sector identifier is mandatory for
+ * this mapper.
+ * The hostname of the sectorIdentifier is used in the hash
+ *
+ * @see <a href=
+ *      "https://docs.oracle.com/en/java/javase/11/docs/specs/security/standard-names.html#mac-algorithms">mac-algorithms</a>
+ */
+public class HmacPairwisePseudonymListMapper extends AbstractOIDCProtocolMapper
+    implements OIDCAccessTokenMapper, OIDCIDTokenMapper, UserInfoTokenMapper
+{
+    private static final Logger LOG = Logger.getLogger(HmacPairwisePseudonymListMapper.class);
+
+    private static final String CLIENT_DOES_NOT_EXIST = "noConfigForClientFoundOrClientDoesNotExist";
+    private static final String       CLAIM_PROP_NAME       = "pseudonymListClaimName";
+    private static final String       CLAIM_PROP_HELP       = "Which claim should hold the pseudonym list";
+    private static final String       CLAIM_PROP_LABEL      = "Target claim for pseudonym list";
+
+    private static final String       CLIENTS_PROP_NAME     = "clients";
+    private static final String       CLIENTS_PROP_HELP     = "List of clients to retrieve and add Pseudonyms for";
+    private static final String       CLIENTS_PROP_LABEL    = "Clients";
+
+    @Override
+    public String getId()
+    {
+        return "oidc-hmac-pairwise-subject-list-mapper";
+    }
+
+    @Override
+    public String getDisplayCategory()
+    {
+        return AbstractOIDCProtocolMapper.TOKEN_MAPPER_CATEGORY;
+    }
+
+    @Override
+    public String getDisplayType()
+    {
+        return "List of HMAC Pairwise subject with static sectorIdentifier";
+    }
+
+    @Override
+    public String getHelpText()
+    {
+        return "Calculates list of pseudonyms using HMACPaiwrwiseSubMapper";
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties()
+    {
+        List<ProviderConfigProperty> configProperties = new LinkedList<>();
+        configProperties.add(createClientListConfig());
+        configProperties.add(createClaimNameConfig());
+        OIDCAttributeMapperHelper.addIncludeInTokensConfig(configProperties, this.getClass());
+        return configProperties;
+    }
+
+    /**
+     * Creates the mapper's configuration property for the client list
+     *
+     * @return Config property item
+     */
+    private ProviderConfigProperty createClientListConfig()
+    {
+        var property = new ProviderConfigProperty();
+        property.setName(CLIENTS_PROP_NAME);
+        property.setType(ProviderConfigProperty.STRING_TYPE);
+        property.setLabel(CLIENTS_PROP_LABEL);
+        property.setHelpText(CLIENTS_PROP_HELP);
+        return property;
+    }
+
+    private ProviderConfigProperty createClaimNameConfig()
+    {
+        var property = new ProviderConfigProperty();
+        property.setName(CLAIM_PROP_NAME);
+        property.setLabel(CLAIM_PROP_LABEL);
+        property.setHelpText(CLAIM_PROP_HELP);
+        property.setType(ProviderConfigProperty.STRING_TYPE);
+        return property;
+    }
+
+    @Override
+    public void validateConfig(KeycloakSession session, RealmModel realm, ProtocolMapperContainerModel mapperContainer,
+                               ProtocolMapperModel mapperModel)
+        throws ProtocolMapperConfigException
+    {
+        if (mapperContainer instanceof ClientModel) {
+            validateAllClientConfigsExist(session, mapperModel);
+        }
+    }
+
+    private void validateAllClientConfigsExist(KeycloakSession session, ProtocolMapperModel mapperModel)
+        throws ProtocolMapperConfigException
+    {
+        List<String> clients = getClients(mapperModel);
+        for (String clientId : clients) {
+
+            if (getProtocollMapperModelForClient(session, clientId).isEmpty()) {
+                throw new ProtocolMapperConfigException(CLIENT_DOES_NOT_EXIST, CLIENT_DOES_NOT_EXIST, clientId);
+            }
+        }
+    }
+
+    private static List<String> getClients(ProtocolMapperModel mapperModel)
+    {
+        return Arrays.asList(mapperModel.getConfig().get(CLIENTS_PROP_NAME).split("#{2}|,"));
+    }
+
+    private static Optional<ProtocolMapperModel> getProtocollMapperModelForClient(KeycloakSession session, String clientId)
+    {
+        return Optional.ofNullable(session.getContext().getRealm().getClientByClientId(clientId.trim()))
+            .flatMap(clientModel -> clientModel.getProtocolMappersStream()
+                .filter(mapper -> mapper.getProtocolMapper().equals(HmacPairwiseSubMapper.PROTOCOLL_MAPPER_ID))
+                .findAny());
+    }
+
+    @Override
+    public IDToken transformIDToken(IDToken token, ProtocolMapperModel mappingModel, KeycloakSession session,
+                                    UserSessionModel userSession,
+                                    ClientSessionContext clientSessionCtx)
+    {
+        if (!OIDCAttributeMapperHelper.includeInIDToken(mappingModel)) {
+            return token;
+        }
+        generatePseudonymListClaim(token, mappingModel, session, userSession.getUser());
+        return token;
+    }
+
+    @Override
+    public AccessToken transformAccessToken(AccessToken token, ProtocolMapperModel mappingModel,
+                                            KeycloakSession session, UserSessionModel userSession,
+                                            ClientSessionContext clientSessionCtx)
+    {
+        if (!OIDCAttributeMapperHelper.includeInAccessToken(mappingModel)) {
+            return token;
+        }
+        generatePseudonymListClaim(token, mappingModel, session, userSession.getUser());
+        return token;
+    }
+
+    @Override
+    public AccessToken transformUserInfoToken(AccessToken token, ProtocolMapperModel mappingModel,
+                                              KeycloakSession session, UserSessionModel userSession,
+                                              ClientSessionContext clientSessionCtx)
+    {
+        if (!OIDCAttributeMapperHelper.includeInUserInfo(mappingModel)) {
+            return token;
+        }
+
+        generatePseudonymListClaim(token, mappingModel, session, userSession.getUser());
+        return token;
+    }
+
+    private void generatePseudonymListClaim(IDToken token, ProtocolMapperModel mappingModel, KeycloakSession session, UserModel user)
+    {
+        for (String client : getClients(mappingModel)) {
+            Optional<ProtocolMapperModel> protocollMapperModelForClient = getProtocollMapperModelForClient(session, client);
+            if (protocollMapperModelForClient.isEmpty()) {
+                LOG.warnf("Could not find HMACPairwiseSubMapperConfig for client %s. Skipping Client", client);
+                continue;
+            }
+
+            String localSub = HmacPairwiseSubMapperHelper.getLocalIdentifierValue(user, protocollMapperModelForClient.get());
+            if (localSub == null) {
+                return;
+            }
+            addPseudonymToTokenClaim(token, mappingModel.getConfig().get(CLAIM_PROP_NAME), client, HmacPairwiseSubMapperHelper
+                .generateIdentifier(protocollMapperModelForClient.get(), localSub));
+        }
+    }
+
+    /**
+     * Add pseudonym to {@link IDToken}, {@link AccessToken} or UserInfoToken claim holding pseudonym
+     * list.
+     *
+     * @param token     Token to extend
+     * @param claim     the claim in which the client-pseudonym map should be stored.
+     * @param clientId  clientId to which the pseudonym belongs
+     * @param pseudonym generated Pairwise hmac subject identifier
+     */
+    protected void addPseudonymToTokenClaim(IDToken token, String claim, String clientId, String pseudonym)
+    {
+        Map<String, String> pseudonyms = (Map<String, String>)token.getOtherClaims().get(claim);
+        if (pseudonyms == null) {
+            pseudonyms = new HashMap<>();
+        }
+        pseudonyms.put(clientId, pseudonym);
+        token.getOtherClaims().put(claim, pseudonyms);
+    }
+}

--- a/hmac-mapper/src/main/java/de/intension/protocol/oidc/mappers/HmacPairwiseSubMapperHelper.java
+++ b/hmac-mapper/src/main/java/de/intension/protocol/oidc/mappers/HmacPairwiseSubMapperHelper.java
@@ -1,0 +1,61 @@
+package de.intension.protocol.oidc.mappers;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
+import java.util.UUID;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.keycloak.models.ProtocolMapperModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.protocol.oidc.mappers.PairwiseSubMapperHelper;
+import org.keycloak.protocol.oidc.utils.PairwiseSubMapperUtils;
+
+public class HmacPairwiseSubMapperHelper {
+
+    private HmacPairwiseSubMapperHelper() {
+    }
+
+    public static String generateIdentifier(ProtocolMapperModel mappingModel, String localSub) {
+        String saltStr = PairwiseSubMapperHelper.getSalt(mappingModel);
+        if (saltStr == null) {
+            throw new IllegalStateException("Salt not available on mappingModel. Please update protocol mapper");
+        }
+        String algorithm = HmacPairwiseSubMapper.getHashAlgorithm(mappingModel);
+        var secretKeySpec = new SecretKeySpec(saltStr.getBytes(StandardCharsets.UTF_8), algorithm);
+        try {
+            var mac = Mac.getInstance(algorithm);
+            mac.init(secretKeySpec);
+            mac.update(getSectorIdentifier(mappingModel).getBytes(StandardCharsets.UTF_8));
+            mac.update(localSub.getBytes(StandardCharsets.UTF_8));
+            return UUID.nameUUIDFromBytes(mac.doFinal()).toString();
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new IllegalStateException("Generating sub failed", e);
+        }
+    }
+
+    /**
+     * Get valid sector identifier from URI.
+     */
+    static String getSectorIdentifier(ProtocolMapperModel mappingModel) {
+        String sectorIdentifierUri = PairwiseSubMapperHelper.getSectorIdentifierUri(mappingModel);
+        return PairwiseSubMapperUtils.resolveValidSectorIdentifier(sectorIdentifierUri);
+    }
+
+    /**
+     * Retrieve the local sub identifier value from the user based on the
+     * configuration in the
+     * mapper.
+     */
+    static String getLocalIdentifierValue(UserModel user, ProtocolMapperModel mappingModel) {
+        String localSubIdentifier = mappingModel.getConfig().get(HmacPairwiseSubMapper.LOCAL_SUB_IDENTIFIER_PROP_NAME);
+
+        if ("id".equals(localSubIdentifier)) {
+            return user.getId();
+        }
+        return user.getAttributeStream(localSubIdentifier).filter(Objects::nonNull).findFirst().orElse(null);
+    }
+}

--- a/hmac-mapper/src/main/java/de/intension/protocol/oidc/mappers/IPairwiseMapper.java
+++ b/hmac-mapper/src/main/java/de/intension/protocol/oidc/mappers/IPairwiseMapper.java
@@ -2,11 +2,7 @@ package de.intension.protocol.oidc.mappers;
 
 import java.util.List;
 
-import org.keycloak.models.ClientModel;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.ProtocolMapperContainerModel;
-import org.keycloak.models.ProtocolMapperModel;
-import org.keycloak.models.RealmModel;
+import org.keycloak.models.*;
 import org.keycloak.protocol.ProtocolMapperConfigException;
 import org.keycloak.protocol.oidc.mappers.OIDCAccessTokenMapper;
 import org.keycloak.protocol.oidc.mappers.OIDCIDTokenMapper;
@@ -22,12 +18,10 @@ import org.keycloak.provider.ProviderConfigProperty;
 public interface IPairwiseMapper
         extends OIDCAccessTokenMapper, OIDCIDTokenMapper, UserInfoTokenMapper {
 
-    String getIdPrefix();
-
     /**
      * Generates a pairwise identifier.
      */
-    String generateIdentifier(ProtocolMapperModel mappingModel, String sectorIdentifier, String localSub);
+    String generateIdentifier(ProtocolMapperModel mappingModel, String localSub);
 
     /**
      * Implement to add additional provider configuration properties.

--- a/hmac-mapper/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
+++ b/hmac-mapper/src/main/resources/META-INF/services/org.keycloak.protocol.ProtocolMapper
@@ -1,2 +1,3 @@
 de.intension.protocol.oidc.mappers.HmacPairwiseSubMapper
 de.intension.protocol.oidc.mappers.HmacPairwiseEmailMapper
+de.intension.protocol.oidc.mappers.HmacPairwisePseudonymListMapper

--- a/hmac-mapper/src/main/resources/theme-resources/messages/messages_de.properties
+++ b/hmac-mapper/src/main/resources/theme-resources/messages/messages_de.properties
@@ -1,0 +1,1 @@
+noConfigForClientFoundOrClientDoesNotExist=HMAC-PairwiseSubMapper Konfiguration für Client {0} nicht gefunden.

--- a/hmac-mapper/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/hmac-mapper/src/main/resources/theme-resources/messages/messages_en.properties
@@ -1,0 +1,1 @@
+noConfigForClientFoundOrClientDoesNotExist=Could not find HMAC Mapper config for Client {0}. Please Check if client exists and has proper config for HmacPairwiseMapper

--- a/hmac-mapper/src/test/java/de/intension/protocol/oidc/mappers/HmacPairwiseSubMapperTest.java
+++ b/hmac-mapper/src/test/java/de/intension/protocol/oidc/mappers/HmacPairwiseSubMapperTest.java
@@ -1,18 +1,14 @@
 package de.intension.protocol.oidc.mappers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.keycloak.protocol.oidc.mappers.PairwiseSubMapperHelper.PAIRWISE_SUB_ALGORITHM_SALT;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.keycloak.models.ClientModel;
@@ -27,14 +23,15 @@ import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.IDToken;
 
-class HmacPairwiseSubMapperTest {
+class HmacPairwiseSubMapperTest
+{
 
-    private static final String ID = "id";
-    static final String USERNAME = "username";
-    private static final String USER_ID = "608b8580-9bcd-4723-be12-1affd60bcc3a";
-    static final String SECTOR_IDENTIFIER = "http://a-static-url.de/sector_identifiers.json";
-    static final String HMAC_SHA_256 = "HmacSHA256";
-    static final String SALT = "P5ZD+fqPLDTW";
+    private static final String ID                = "id";
+    static final String         USERNAME          = "username";
+    private static final String USER_ID           = "608b8580-9bcd-4723-be12-1affd60bcc3a";
+    static final String         SECTOR_IDENTIFIER = "http://a-static-url.de/sector_identifiers.json";
+    static final String         HMAC_SHA_256      = "HmacSHA256";
+    static final String         SALT              = "P5ZD+fqPLDTW";
 
     /**
      * GIVEN: a user, same salt, hash algorithm, sector identifier
@@ -43,13 +40,14 @@ class HmacPairwiseSubMapperTest {
      * THEN: resulting subject value is same
      */
     @Test
-    void should_generate_same_subject_value_when_same_local_sub_identifier_value() {
+    void should_generate_same_subject_value_when_same_local_sub_identifier_value()
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
 
         AccessToken accessToken = mapper.transformAccessToken(new AccessToken(), createMapperModel(USERNAME), null,
-                mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
+                                                              mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
         AccessToken accessToken2 = mapper.transformAccessToken(new AccessToken(), createMapperModel(USERNAME), null,
-                mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
+                                                               mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
 
         assertEquals(accessToken.getSubject(), accessToken2.getSubject());
     }
@@ -61,13 +59,14 @@ class HmacPairwiseSubMapperTest {
      * THEN: resulting subject value is not same
      */
     @Test
-    void should_generate_different_subject_value_when_different_local_sub_identifier_value() {
+    void should_generate_different_subject_value_when_different_local_sub_identifier_value()
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
 
         AccessToken accessToken = mapper.transformAccessToken(new AccessToken(), createMapperModel(USERNAME), null,
-                mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
+                                                              mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
         AccessToken accessToken2 = mapper.transformAccessToken(new AccessToken(), createMapperModel(ID), null,
-                mockUserSessionModel(USER_ID, USERNAME, USER_ID), null);
+                                                               mockUserSessionModel(USER_ID, USERNAME, USER_ID), null);
 
         assertNotEquals(accessToken.getSubject(), accessToken2.getSubject());
     }
@@ -78,13 +77,14 @@ class HmacPairwiseSubMapperTest {
      * THEN: resulting subject value is same
      */
     @Test
-    void should_generate_same_subject_value_for_id_token_when_same_local_sub_identifier_value() {
+    void should_generate_same_subject_value_for_id_token_when_same_local_sub_identifier_value()
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
 
         IDToken idToken = mapper.transformIDToken(new IDToken(), createMapperModel(USERNAME), null,
-                mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
+                                                  mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
         IDToken idToken2 = mapper.transformIDToken(new IDToken(), createMapperModel(USERNAME), null,
-                mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
+                                                   mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
 
         assertEquals(idToken.getSubject(), idToken2.getSubject());
     }
@@ -96,13 +96,14 @@ class HmacPairwiseSubMapperTest {
      * THEN: resulting sub in claim is same
      */
     @Test
-    void should_generate_same_subject_value_for_user_info_token_when_same_local_sub_identifier_value() {
+    void should_generate_same_subject_value_for_user_info_token_when_same_local_sub_identifier_value()
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
 
         AccessToken accessToken = mapper.transformUserInfoToken(new AccessToken(), createMapperModel(USERNAME), null,
-                mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
+                                                                mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
         AccessToken accessToken2 = mapper.transformUserInfoToken(new AccessToken(), createMapperModel(USERNAME), null,
-                mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
+                                                                 mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
 
         assertEquals(accessToken.getOtherClaims().get("sub"), accessToken2.getOtherClaims().get("sub"));
     }
@@ -113,12 +114,13 @@ class HmacPairwiseSubMapperTest {
      * THEN: sub is not changed on the access token
      */
     @Test
-    void should_throw_run_time_exception_when_empty_local_sub_identifier_value() {
+    void should_throw_run_time_exception_when_empty_local_sub_identifier_value()
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
         AccessToken token = new AccessToken().subject("before");
 
         mapper.transformAccessToken(token, createMapperModel("wrongLocalSubIdentifier"), null,
-                mockUserSessionModel(USER_ID, "wrongLocalSubIdentifier", null), null);
+                                    mockUserSessionModel(USER_ID, "wrongLocalSubIdentifier", null), null);
 
         assertEquals("before", token.getSubject());
 
@@ -130,15 +132,16 @@ class HmacPairwiseSubMapperTest {
      * THEN: resulting subject value is not same
      */
     @Test
-    void should_generate_different_subject_value_when_different_salt() {
+    void should_generate_different_subject_value_when_different_salt()
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
 
         AccessToken accessToken = mapper.transformAccessToken(new AccessToken(), createMapperModel(USERNAME), null,
-                mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
+                                                              mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
         ProtocolMapperModel anotherSaltProtocolMapper = createMapperModel(USERNAME, HMAC_SHA_256, "Azhdfopek",
-                SECTOR_IDENTIFIER);
+                                                                          SECTOR_IDENTIFIER);
         AccessToken accessToken2 = mapper.transformAccessToken(new AccessToken(), anotherSaltProtocolMapper, null,
-                mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
+                                                               mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
 
         assertNotEquals(accessToken.getSubject(), accessToken2.getSubject());
     }
@@ -150,15 +153,16 @@ class HmacPairwiseSubMapperTest {
      * THEN: resulting subject value is not same
      */
     @Test
-    void should_generate_different_subject_value_when_different_sectorIdentifier() {
+    void should_generate_different_subject_value_when_different_sectorIdentifier()
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
 
         AccessToken accessToken = mapper.transformAccessToken(new AccessToken(), createMapperModel(USERNAME), null,
-                mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
+                                                              mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
         ProtocolMapperModel anotherSaltProtocolMapper = createMapperModel(USERNAME, HMAC_SHA_256, SALT,
-                "http://www.example.de");
+                                                                          "http://www.example.de");
         AccessToken accessToken2 = mapper.transformAccessToken(new AccessToken(), anotherSaltProtocolMapper, null,
-                mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
+                                                               mockUserSessionModel(USER_ID, USERNAME, "tim"), null);
 
         assertNotEquals(accessToken.getSubject(), accessToken2.getSubject());
     }
@@ -169,13 +173,12 @@ class HmacPairwiseSubMapperTest {
      * THEN: IllegalStateException is thrown with expected message
      */
     @Test
-    void should_throw_illegal_state_exception_when_salt_not_configured() {
+    void should_throw_illegal_state_exception_when_salt_not_configured()
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
         ProtocolMapperModel noSaltProtocolMapper = createMapperModel(USERNAME, HMAC_SHA_256, null, SECTOR_IDENTIFIER);
 
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
-            mapper.generateIdentifier(noSaltProtocolMapper, SECTOR_IDENTIFIER, USER_ID);
-        });
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> mapper.generateIdentifier(noSaltProtocolMapper, USER_ID));
 
         assertEquals("Salt not available on mappingModel. Please update protocol mapper", exception.getMessage());
     }
@@ -186,14 +189,13 @@ class HmacPairwiseSubMapperTest {
      * THEN: IllegalStateException is thrown with expected message
      */
     @Test
-    void should_throw_illegal_state_exception_when_wrong_algorithm_configured() {
+    void should_throw_illegal_state_exception_when_wrong_algorithm_configured()
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
         ProtocolMapperModel wrongAlgorithmProtocolMapper = createMapperModel(USERNAME, "wrongAlgorithm", SALT,
-                SECTOR_IDENTIFIER);
+                                                                             SECTOR_IDENTIFIER);
 
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
-            mapper.generateIdentifier(wrongAlgorithmProtocolMapper, SECTOR_IDENTIFIER, USER_ID);
-        });
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> mapper.generateIdentifier(wrongAlgorithmProtocolMapper, USER_ID));
 
         assertEquals("Generating sub failed", exception.getMessage());
     }
@@ -204,13 +206,13 @@ class HmacPairwiseSubMapperTest {
      * THEN: ProtocolMapperConfigException is thrown with expected message
      */
     @Test
-    void should_throw_protocol_mapper_config_exception_when_no_sector_identifier_configured() {
+    void should_throw_protocol_mapper_config_exception_when_no_sector_identifier_configured()
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
         ProtocolMapperModel noSectorIdentifierProtocolMapper = createMapperModel(USERNAME, HMAC_SHA_256, SALT, null);
 
-        ProtocolMapperConfigException exception = assertThrows(ProtocolMapperConfigException.class, () -> {
-            mapper.validateSectorIdentifier(null, null, noSectorIdentifierProtocolMapper);
-        });
+        ProtocolMapperConfigException exception = assertThrows(ProtocolMapperConfigException.class,
+                                                               () -> mapper.validateSectorIdentifier(null, null, noSectorIdentifierProtocolMapper));
 
         assertEquals("Sector Identifier must not be null or empty.", exception.getMessage());
     }
@@ -221,13 +223,13 @@ class HmacPairwiseSubMapperTest {
      * THEN: ProtocolMapperConfigException is thrown with expected message
      */
     @Test
-    void should_throw_protocol_mapper_config_exception_when_empty_sector_identifier_configured() {
+    void should_throw_protocol_mapper_config_exception_when_empty_sector_identifier_configured()
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
         ProtocolMapperModel emptySectorIdentifierProtocolMapper = createMapperModel(USERNAME, HMAC_SHA_256, SALT, "");
 
-        ProtocolMapperConfigException exception = assertThrows(ProtocolMapperConfigException.class, () -> {
-            mapper.validateSectorIdentifier(null, null, emptySectorIdentifierProtocolMapper);
-        });
+        ProtocolMapperConfigException exception = assertThrows(ProtocolMapperConfigException.class,
+                                                               () -> mapper.validateSectorIdentifier(null, null, emptySectorIdentifierProtocolMapper));
 
         assertEquals("Sector Identifier must not be null or empty.", exception.getMessage());
     }
@@ -238,14 +240,14 @@ class HmacPairwiseSubMapperTest {
      * THEN: ProtocolMapperConfigException is thrown with expected message
      */
     @Test
-    void should_throw_protocol_mapper_config_exception_when_invalid_sector_identifier_configured() {
+    void should_throw_protocol_mapper_config_exception_when_invalid_sector_identifier_configured()
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
         ProtocolMapperModel invalidSectorIdentifierProtocolMapper = createMapperModel(USERNAME, HMAC_SHA_256, SALT,
-                "invalidSectorIdentifier");
+                                                                                      "invalidSectorIdentifier");
 
-        ProtocolMapperConfigException exception = assertThrows(ProtocolMapperConfigException.class, () -> {
-            mapper.validateSectorIdentifier(null, null, invalidSectorIdentifierProtocolMapper);
-        });
+        ProtocolMapperConfigException exception = assertThrows(ProtocolMapperConfigException.class,
+                                                               () -> mapper.validateSectorIdentifier(null, null, invalidSectorIdentifierProtocolMapper));
 
         assertEquals("Invalid Sector Identifier URI.", exception.getMessage());
     }
@@ -256,14 +258,14 @@ class HmacPairwiseSubMapperTest {
      * THEN: ProtocolMapperConfigException is thrown with expected message
      */
     @Test
-    void should_throw_protocol_mapper_config_exception_when_malformed_sector_identifier_configured() {
+    void should_throw_protocol_mapper_config_exception_when_malformed_sector_identifier_configured()
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
         ProtocolMapperModel malformedSectorIdentifierProtocolMapper = createMapperModel(USERNAME, HMAC_SHA_256, SALT,
-                "http://finance.yahoo.com/q/h?s=^IXIC");
+                                                                                        "http://finance.yahoo.com/q/h?s=^IXIC");
 
-        ProtocolMapperConfigException exception = assertThrows(ProtocolMapperConfigException.class, () -> {
-            mapper.validateSectorIdentifier(null, null, malformedSectorIdentifierProtocolMapper);
-        });
+        ProtocolMapperConfigException exception = assertThrows(ProtocolMapperConfigException.class,
+                                                               () -> mapper.validateSectorIdentifier(null, null, malformedSectorIdentifierProtocolMapper));
 
         assertEquals("Invalid Sector Identifier URI.", exception.getMessage());
     }
@@ -274,14 +276,14 @@ class HmacPairwiseSubMapperTest {
      * THEN: ProtocolMapperConfigException is thrown with expected message
      */
     @Test
-    void should_throw_protocol_mapper_config_exception_when_wrong_algorithm_configured() {
+    void should_throw_protocol_mapper_config_exception_when_wrong_algorithm_configured()
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
         ProtocolMapperModel noAlgorithmProtocolMapper = createMapperModel(USERNAME, "wrongAlgorithm", SALT,
-                SECTOR_IDENTIFIER);
+                                                                          SECTOR_IDENTIFIER);
 
-        ProtocolMapperConfigException exception = assertThrows(ProtocolMapperConfigException.class, () -> {
-            mapper.validateConfig(null, null, null, noAlgorithmProtocolMapper);
-        });
+        ProtocolMapperConfigException exception = assertThrows(ProtocolMapperConfigException.class,
+                                                               () -> mapper.validateConfig(null, null, null, noAlgorithmProtocolMapper));
 
         assertEquals("Hash algorithm 'wrongAlgorithm' cannot be found", exception.getMessage());
     }
@@ -293,7 +295,8 @@ class HmacPairwiseSubMapperTest {
      */
     @Test
     void should_generate_salt_when_none_configured()
-            throws Exception {
+        throws Exception
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
         ProtocolMapperModel noSaltProtocolMapper = createMapperModel(USERNAME, HMAC_SHA_256, null, SECTOR_IDENTIFIER);
 
@@ -309,7 +312,8 @@ class HmacPairwiseSubMapperTest {
      */
     @Test
     void should_generate_salt_when_empty_salt_configured()
-            throws Exception {
+        throws Exception
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
         ProtocolMapperModel emptySaltProtocolMapper = createMapperModel(USERNAME, HMAC_SHA_256, "", SECTOR_IDENTIFIER);
 
@@ -325,7 +329,8 @@ class HmacPairwiseSubMapperTest {
      */
     @Test
     void should_contain_config_properties_when_configured()
-            throws Exception {
+        throws Exception
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
 
         List<ProviderConfigProperty> configProperties = mapper.getConfigProperties();
@@ -341,7 +346,8 @@ class HmacPairwiseSubMapperTest {
      */
     @Test
     void should_contain_contenated_id_of_hmac_pairwise_mapper()
-            throws Exception {
+        throws Exception
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
         assertEquals("oidc-hmac-pairwise-subject-mapper", mapper.getId());
     }
@@ -353,7 +359,8 @@ class HmacPairwiseSubMapperTest {
      */
     @Test
     void should_have_token_mapper_category_for_hmac_pairwise_mapper()
-            throws Exception {
+        throws Exception
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
         assertEquals(AbstractOIDCProtocolMapper.TOKEN_MAPPER_CATEGORY, mapper.getDisplayCategory());
     }
@@ -365,7 +372,8 @@ class HmacPairwiseSubMapperTest {
      */
     @Test
     void should_have_expected_display_type_for_hmac_pairwise_mapper()
-            throws Exception {
+        throws Exception
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
         assertEquals("HMAC Pairwise subject with static sectorIdentifier", mapper.getDisplayType());
     }
@@ -381,11 +389,12 @@ class HmacPairwiseSubMapperTest {
      */
     @Test
     void should_have_expected_help_text_for_hmac_pairwise_mapper()
-            throws Exception {
+        throws Exception
+    {
         HmacPairwiseSubMapper mapper = new HmacPairwiseSubMapper();
         assertEquals(
-                "Calculates a pairwise subject identifier using a salted HMAC hash and sectorIdentifier. See OpenID Connect specification for more info about pairwise subject identifiers.",
-                mapper.getHelpText());
+                     "Calculates a pairwise subject identifier using a salted HMAC hash and sectorIdentifier. See OpenID Connect specification for more info about pairwise subject identifiers.",
+                     mapper.getHelpText());
     }
 
     /**
@@ -398,7 +407,8 @@ class HmacPairwiseSubMapperTest {
      * @return
      */
     private ProtocolMapperModel createMapperModel(String localSubIdentifier, String hashAlgorithm, String salt,
-            String sectorIdentifier) {
+                                                  String sectorIdentifier)
+    {
         ProtocolMapperModel protocolMapperModel = new ProtocolMapperModel();
         protocolMapperModel.setConfig(new HashMap<String, String>());
         protocolMapperModel.setName("HMAC Mapper");
@@ -414,18 +424,20 @@ class HmacPairwiseSubMapperTest {
         return protocolMapperModel;
     }
 
-    private ProtocolMapperModel createMapperModel(String localSubIdentifier) {
+    private ProtocolMapperModel createMapperModel(String localSubIdentifier)
+    {
         return createMapperModel(localSubIdentifier, HMAC_SHA_256, SALT, SECTOR_IDENTIFIER);
     }
 
     private static UserSessionModel mockUserSessionModel(String id, String localSubIdentifier,
-            String localSubIdentifierValue) {
+                                                         String localSubIdentifierValue)
+    {
         UserSessionModel userSessionModel = mock(UserSessionModel.class);
         UserModel userModel = mock(UserModel.class);
         when(userModel.getId()).thenReturn(id);
         when(userModel.getAttributeStream(localSubIdentifier))
-                .thenReturn(localSubIdentifierValue != null ? Arrays.asList(localSubIdentifierValue).stream()
-                        : Collections.<String>emptyList().stream());
+            .thenReturn(localSubIdentifierValue != null ? Stream.of(localSubIdentifierValue)
+                    : Stream.empty());
         when(userSessionModel.getUser()).thenReturn(userModel);
         return userSessionModel;
     }


### PR DESCRIPTION

adds another OIDC protocoll-mapper which calculates the pseudonyms of a given list of clients. It uses the original client mapper configuration for the given clients. 
Checks Clients on Save. If Client is removed later client is skipped only with a warning in the log.

Todo Unit and postman tests.

FWUV-126